### PR TITLE
iOS fix for Indexed-DB-Shim

### DIFF
--- a/plugins/treo-websql/indexeddb-shim.js
+++ b/plugins/treo-websql/indexeddb-shim.js
@@ -1584,9 +1584,7 @@ var cleanInterface = false;
             var calledDbCreateError = false;
 
             sysdb.transaction(function(tx){
-                tx.executeSql("CREATE TABLE IF NOT EXISTS dbVersions (name VARCHAR(255), version INT);", [], function(){
-                   updateVersions(); 
-                });
+                tx.executeSql("CREATE TABLE IF NOT EXISTS dbVersions (name VARCHAR(255), version INT);", [], updateVersions);
             }, function() {
                idbModules.DEBUG && console.log("Error in sysdb transaction - when creating dbVersions", arguments);
             });

--- a/plugins/treo-websql/indexeddb-shim.js
+++ b/plugins/treo-websql/indexeddb-shim.js
@@ -1572,11 +1572,6 @@ var cleanInterface = false;
     }
     // The sysDB to keep track of version numbers for databases
     var sysdb = window.openDatabase("__sysdb__", 1, "System Database", DEFAULT_DB_SIZE);
-    sysdb.transaction(function(tx){
-        tx.executeSql("CREATE TABLE IF NOT EXISTS dbVersions (name VARCHAR(255), version INT);", []);
-    }, function() {
-       idbModules.DEBUG && console.log("Error in sysdb transaction - when creating dbVersions", arguments);
-    });
 
     var shimIndexedDB = {
         /**
@@ -1587,6 +1582,14 @@ var cleanInterface = false;
         open: function(name, version){
             var req = new idbModules.IDBOpenRequest();
             var calledDbCreateError = false;
+
+            sysdb.transaction(function(tx){
+                tx.executeSql("CREATE TABLE IF NOT EXISTS dbVersions (name VARCHAR(255), version INT);", [], function(){
+                   updateVersions(); 
+                });
+            }, function() {
+               idbModules.DEBUG && console.log("Error in sysdb transaction - when creating dbVersions", arguments);
+            });
 
             function dbCreateError(){
                 if (calledDbCreateError) {
@@ -1636,18 +1639,20 @@ var cleanInterface = false;
                 }, dbCreateError);
             }
 
-            sysdb.transaction(function(tx){
-                tx.executeSql("SELECT * FROM dbVersions where name = ?", [name], function(tx, data){
-                    if (data.rows.length === 0) {
-                        // Database with this name does not exist
-                        tx.executeSql("INSERT INTO dbVersions VALUES (?,?)", [name, version || 1], function(){
-                            openDB(0);
-                        }, dbCreateError);
-                    } else {
-                        openDB(data.rows.item(0).version);
-                    }
+            function updateVersions() {
+                sysdb.transaction(function(tx){
+                    tx.executeSql("SELECT * FROM dbVersions where name = ?", [name], function(tx, data){
+                        if (data.rows.length === 0) {
+                            // Database with this name does not exist
+                            tx.executeSql("INSERT INTO dbVersions VALUES (?,?)", [name, version || 1], function(){
+                                openDB(0);
+                            }, dbCreateError);
+                        } else {
+                            openDB(data.rows.item(0).version);
+                        }
+                    }, dbCreateError);
                 }, dbCreateError);
-            }, dbCreateError);
+            }
 
             return req;
         },


### PR DESCRIPTION
This fixes the iOS issue on IndexedDBShim https://github.com/axemclion/IndexedDBShim/issues/167

Apparently, the code would try to select and insert values in ```dbVersions``` before this was created, there was a race condition. Solution was to include this logic on the callback of creating ```dbVersions```